### PR TITLE
fix: move CNAME marker to the right location

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-areweloongyet.com

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+areweloongyet.com


### PR DESCRIPTION
I selected the wrong branch for GHP so this was added to the wrong place. Move it so gh-pages build would get it.