### PR TITLE
feat(data): add LFS to list of distros

### DIFF
--- a/src/data/07-distros/lfs.yml
+++ b/src/data/07-distros/lfs.yml
@@ -1,0 +1,11 @@
+name: 'LFS LoongArch Edition'
+homepageURL: 'https://www.linuxfromscratch.org/~xry111/lfs/'
+repoURL: 'https://git.linuxfromscratch.org/lfs.git'
+portingEfforts:
+  - authors: ['xry111']
+    desc: 'Linux From Scratch 主分支近期无支持非 x86 架构的计划，其他架构支持均为独立项目：xry111/loongarch 分支本身即为上游'
+    link: 'https://wiki.linuxfromscratch.org/lfs/log/?rev=xry111/loongarch'
+    supportStatus: WIP
+    releasedSinceVersion: '12.0'
+    goodSinceVersion: '12.0'
+    quality: NoCode


### PR DESCRIPTION
This is fully working now, but before LFS 12.0 release we'll have some major changes: GCC-13.2, Binutils-2.41 (I hope the "relaxation" stuff won't break things!), Glibc-2.38, and for the SysV revision replacing Eudev with Udev extracted from systemd.  So set the status to WIP for now.

Closes #25.