### PR TITLE
Merge micronews site into AWLY

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,6 +92,14 @@ const config = {
         path: './newsletter',
       },
     ],
+    [
+      '@docusaurus/plugin-content-blog',
+      {
+        id: 'blog-micronews',
+        routeBasePath: 'micronews',
+        path: './micronews',
+      },
+    ],
   ],
 
   presets: [
@@ -138,6 +146,7 @@ const config = {
           },
           // {to: '/asmdb', label: '汇编指令速查', position: 'left'},
           {to: '/newsletter', label: '每周一龙', position: 'left'},
+          {to: '/micronews', label: '狗剩微闻', position: 'left'},
           {to: '/blog', label: '本站动态', position: 'left'},
           {
             href: 'https://github.com/loongson-community/areweloongyet',
@@ -155,6 +164,10 @@ const config = {
               {
                 label: '每周一龙',
                 to: '/newsletter',
+              },
+              {
+                label: '狗剩微闻',
+                to: '/micronews',
               },
               {
                 label: '本站动态',

--- a/micronews/2023-07-20-new-home-for-micronews.md
+++ b/micronews/2023-07-20-new-home-for-micronews.md
@@ -1,0 +1,14 @@
+---
+slug: new-home-for-micronews
+title: 《狗剩微闻》与《咱龙了吗？》正式合并
+authors: [xen0n]
+tags: [announcement]
+---
+
+[《狗剩微闻》][micronews]是 blah blah。
+由于 blah blah 的原因，《狗剩微闻》与本站的维护者们商议后决定合并两个项目。
+blah blah blah
+
+TODO: 把通稿写完，标题也最好改改
+
+[micronews]: https://github.com/loongson-community/micronews

--- a/micronews/authors.yml
+++ b/micronews/authors.yml
@@ -1,0 +1,1 @@
+../blog/authors.yml


### PR DESCRIPTION
In the wake of https://github.com/loongson-community/micronews/issues/79.

* [x] spin up a new blog
* [ ] convert article data from micronews to a more workable form
* [ ] import said data here as Markdown blog articles
* [ ] theming
* [ ] make sure the generated feed stays compatible/similar enough
* [ ] write the PR announcement

Or in case the default blog seems too heavyweight still:

* [ ] develop a new blog theme and ensure the feeds are in order
* [ ] import the micronews content in mostly machine-oriented form

In all cases, to migrate the existing lightweight posting flow:

* [ ] setup GHA looking at issues specifically labeled as micronews submissions
* [ ] add issue template
* [ ] migrate the submission guide here

cc @loongson-community/publicity