### PR TITLE
fix: revert CNAME to production domain

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-source.areweloongyet.com
+areweloongyet.com


### PR DESCRIPTION
Otherwise non-canonical paths like `/blog` (note the lack of a trailing `/`) are going to be 301'd to this CNAME, which will get cached by the CDN, causing the user to be bumped to source site.

Modern CDNs can be configured to pass-through the Host field though, so we can leave this alone and just let the CDN make requests to the GitHub Pages domain but with the correct Host. This will enable direct resolution to the GHP CDN in case of requests not from CN too.