### PR TITLE
《每周一龙》第 28 期 AOSC 贡献者（白铭骢、傅孝元）更名

### DIFF
--- a/newsletter/2023-12-11-this-week-in-loongarch-28/index.md
+++ b/newsletter/2023-12-11-this-week-in-loongarch-28/index.md
@@ -143,9 +143,9 @@ LoongArch 支持补丁，已为 AMD 维护者所确认：将进入 ROCm 6.1 官�
 
 [Xinmudotmoe]: https://github.com/Xinmudotmoe
 
-AOSC 贡献者 [eatradish](https://github.com/eatradish) 为 Rust 的 Lua 绑定库
+AOSC 贡献者 [傅孝元](https://github.com/eatradish) 为 Rust 的 Lua 绑定库
 mlua [新增了](https://github.com/khvzak/mlua/pull/339) LoongArch 支持。
-感谢 [MingcongBai](https://github.com/MingcongBai) 投递新闻线索！
+感谢 [白铭骢](https://github.com/MingcongBai) 投递新闻线索！
 
 ## 社区整活:儿: {#grins}
 

--- a/newsletter/2023-12-11-this-week-in-loongarch-28/index.md
+++ b/newsletter/2023-12-11-this-week-in-loongarch-28/index.md
@@ -143,9 +143,9 @@ LoongArch 支持补丁，已为 AMD 维护者所确认：将进入 ROCm 6.1 官�
 
 [Xinmudotmoe]: https://github.com/Xinmudotmoe
 
-AOSC 贡献者 [傅孝元](https://github.com/eatradish) 为 Rust 的 Lua 绑定库
+AOSC 贡献者[傅孝元](https://github.com/eatradish)为 Rust 的 Lua 绑定库
 mlua [新增了](https://github.com/khvzak/mlua/pull/339) LoongArch 支持。
-感谢 [白铭骢](https://github.com/MingcongBai) 投递新闻线索！
+感谢[白铭骢](https://github.com/MingcongBai)投递新闻线索！
 
 ## 社区整活:儿: {#grins}
 


### PR DESCRIPTION
更改在正文中白铭骢（原为 Mingcong Bai）和傅孝元（原为 eatradish）的称呼；均使用中文真名。

本 PR 已征得 @eatradish 许可。