### PR TITLE
将Wasmtime加入运行时跟踪

### DIFF
--- a/src/data/06-jit-runtimes/wasmtime.yml
+++ b/src/data/06-jit-runtimes/wasmtime.yml
@@ -1,0 +1,4 @@
+name: 'Wasmtime'
+homepageURL: 'https://wasmtime.dev/'
+repoURL: 'https://github.com/bytecodealliance/wasmtime'
+portingEfforts: []


### PR DESCRIPTION
Wasmtime是 [Bytecode Alliance](https://bytecodealliance.org/) 研发的 [WebAssembly System Interface](https://wasi.dev) 运行时。

根据该项目的文档描述，loongarch架构当前 [尚未支持](https://docs.wasmtime.dev/stability-tiers.html) 且项目方 [欢迎更多的架构](https://docs.wasmtime.dev/stability-tiers.html#unsupported-features-and-platforms) 。

本提交将该运行时加入首页追踪列表。

在有rust环境的情况下， `cargo install wasmtime` 即可安装此运行时，
经测试，当前在loongarch64上不能安装。