### PR TITLE
Add LoongFire to list of distros

### DIFF
--- a/src/data/07-distros/loongfire.yml
+++ b/src/data/07-distros/loongfire.yml
@@ -1,0 +1,11 @@
+name: 'LoongFire'
+homepageURL: 'https://www.bpfire.net'
+repoURL: 'https://github.com/vincentmli/BPFire/tree/loongfire'
+portingEfforts:
+  - authors: ['vincentmli']
+    desc: 'LoongFire is fork of IPFire 2.x, a hardened, versatile, state-of-the-art Open Source firewall based on Linux. LoongFire is to port IPFire to Loongson Loongarch64 architecture. No plan to upstream to IPFire'
+    link: 'https://www.bpfire.net/download/ipfire-2.29-core190-loongarch64.img.xz'
+    supportStatus: WaitingRelease
+    releasedSinceVersion: ''
+    goodSinceVersion: ''
+    quality: OnPar

--- a/src/data/porters.yml
+++ b/src/data/porters.yml
@@ -91,6 +91,12 @@ sunhaiyong1978:
   url: ''
   githubUsername: sunhaiyong1978
   giteeUsername: ''
+vincentmli:
+  name: Vincent Li
+  kind: Community
+  url: https://github.com/vincentmli
+  githubUsername: vincentmli
+  giteeUsername: vincentmli
 xen0n:
   name: WANG Xuerui
   kind: Community


### PR DESCRIPTION
LoongFire is fork of Open Source Firewall IPFire [0],  and to port IPFire to LoongSon LoongArch64 architecture.

[0]: https://ipfire.org