### PR TITLE
Update LoongFire flash image download link

### DIFF
--- a/src/data/07-distros/loongfire.yml
+++ b/src/data/07-distros/loongfire.yml
@@ -4,7 +4,7 @@ repoURL: 'https://github.com/vincentmli/BPFire/tree/loongfire'
 portingEfforts:
   - authors: ['vincentmli']
     desc: 'LoongFire is fork of IPFire 2.x, a hardened, versatile, state-of-the-art Open Source firewall based on Linux. LoongFire is to port IPFire to Loongson Loongarch64 architecture. No plan to upstream to IPFire'
-    link: 'https://www.bpfire.net/download/ipfire-2.29-core190-loongarch64.img.xz'
+    link: 'https://www.vcn.bc.ca/~vli/bpfire/ipfire-2.29-core190-loongarch64.img.xz'
     supportStatus: WaitingRelease
     releasedSinceVersion: ''
     goodSinceVersion: ''


### PR DESCRIPTION
Hi @xen0n 

This is to update the loongfire flash image download link, previous download link seems to be blocked from mainland China, this new link seems not blocked from mainland, if you can verify that, it is even better :)

