### PR TITLE
docs: add specific version for old-world distros

### DIFF
--- a/docs/old-and-new-worlds.md
+++ b/docs/old-and-new-worlds.md
@@ -50,13 +50,13 @@ MIPS 型号的龙芯既不是新世界也不是旧世界。
 
 如果符合以下任一条件，你就在用**旧世界**：
 
-* 系统是麒麟、Loongnix、UOS 其中之一
-* 内核版本以 4.19 开头
+* 系统是麒麟 V10、Loongnix 20、UOS V20 其中之一
+* 内核版本以 4.19、5.4 或 5.10 开头
 * 有 WPS 用但没有安装过 `libLoL` 等旧世界兼容方案
 
 如果一条都没中，你就在用**新世界**。
 
-这个判断方法是基于 2024 年 2 月的已知信息设计的。
+这个判断方法是基于 2026 年 4 月的已知信息设计的。
 后续如果没及时更新，可能会不准。
 
 ## 手头这软件是哪个世界的？
@@ -77,6 +77,14 @@ interpreter /lib64/ld-linux-loongarch-lp64d.so.1, for GNU/Linux 5.19.0
 ```
 
 就表明这是一个新世界程序。
+
+除此之外，可能还会在如 OpenCloudOS 这类系统上看到含有如下字样的输出：
+
+```
+interpreter /lib64/ld-linux-loongarch-lp64d.so.1, for GNU/Linux 4.19.0
+```
+
+需要注意的是，该程序本质上依然是新世界程序。出现 4.19.0 字样的原因，是其编译环境中的 glibc 增加一个[特殊补丁](https://raw.gitcode.com/src-openeuler/glibc/raw/fd8447e5f44da8f89a1f9e7440fb0f4d2e43e77f/Decrease-value-of-arch_minimum_kernel-with-LoongArch.patch)，从而导致了这种信息的输出。
 
 以上的判断都适用于系统 libc 为 glibc 且动态链接的程序。如果程序是静态链接的，便没有 interpreter 信息；
 如果程序是 Go 语言的或者使用了 musl 作为 C 库，那么文件里就没有对应到 `for GNU/Linux` 这部分信息的标记。
@@ -128,9 +136,9 @@ Macintosh 电脑的不同型号就使用 Old World、New World 来区分。
 
 目前已知的旧世界发行版（移植）有：（按英文名字母顺序排序）
 
-* 麒麟 (Kylin)
-* Loongnix
-* UOS
+* 麒麟 (Kylin) V10
+* Loongnix 20
+* UOS V20
 
 目前已知的新世界发行版（移植）有：（按英文名字母顺序排序）
 
@@ -140,8 +148,11 @@ Macintosh 电脑的不同型号就使用 Old World、New World 来区分。
 * [Debian](https://wiki.debian.org/Ports/loong64)
 * [Fedora LoongArch Remix](https://github.com/fedora-remix-loongarch/releases-info)
 * [Gentoo](https://wiki.gentoo.org/wiki/Project:LoongArch)
+* [麒麟 (Kylin) V11](https://www.kylinos.cn/productPc/desktop/desktopMainV11/)
 * [Loong Arch Linux](https://github.com/loongarchlinux)
+* [Loongnix 25](https://www.loongnix.cn/zh/loongnix/)
 * [Slackware](https://github.com/shipujin/slackware-loongarch64)
+* [UOS V25](https://www.chinauos.com/resource/download-professional-V25)
 * [Yongbao](https://github.com/sunhaiyong1978/Yongbao)
 
 :::warning

--- a/i18n/en/docusaurus-plugin-content-docs/current/old-and-new-worlds.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/old-and-new-worlds.md
@@ -40,13 +40,13 @@ The terms "旧世界" and "新世界" are translated into English as "the old wo
 
 If any of the following conditions apply, you are using the **old world**:
 
-* The system is one of Kylin, Loongnix, or UOS.
-* The kernel version starts with 4.19.
+* The system is one of Kylin V10, Loongnix 20, or UOS V20.
+* The kernel version starts with 4.19, 5.4 or 5.10.
 * You use WPS but have not installed `libLoL` or other old-world compatibility solutions.
 
 If none of these conditions apply, you are using the **new world**.
 
-This method of determination is based on known information as of February 2024. It may become inaccurate if not updated in time.
+This method of determination is based on known information as of April 2026. It may become inaccurate if not updated in time.
 
 ## Which World Does This Software Belong To?
 
@@ -65,6 +65,14 @@ interpreter /lib64/ld-linux-loongarch-lp64d.so.1, for GNU/Linux 5.19.0
 ```
 
 it indicates that this is a new-world program.
+
+Additionally, on systems such as OpenCloudOS you may observe output resembling the following:
+
+```
+interpreter /lib64/ld-linux-loongarch-lp64d.so.1, for GNU/Linux 4.19.0
+```
+
+It is important to note that the binary in question is still fundamentally a new-world program. The appearance of the "4.19.0" string is due to a [special patch](https://raw.gitcode.com/src-openeuler/glibc/raw/fd8447e5f44da8f89a1f9e7440fb0f4d2e43e77f/Decrease-value-of-arch_minimum_kernel-with-LoongArch.patch) applied to glibc in its build environment, which modifies the reported minimum kernel version for LoongArch.
 
 The above judgments apply to dynamically linked programs with glibc as the system libc. If the program is statically linked, there will be no interpreter information; if the program is written in Go or uses musl as the C library, there will be no `for GNU/Linux` marker in the file. In such cases, try running it—programs from the "other world" are unlikely to start normally.
 
@@ -92,9 +100,9 @@ On the other hand, users of Linux source-based distributions (such as Gentoo) of
 **Available distributions.** Old-world distributions are only produced by a few commercial companies because the full source code is not publicly available. All community distributions belong to the new world.
 
 Known old-world (ports) distributions (alphabetical):
-* 麒麟 (Kylin)
-* Loongnix
-* UOS
+* 麒麟 (Kylin) V10
+* Loongnix 20
+* UOS V20
 
 Known new-world (ports) distributions (alphabetical):
 * [ALT Linux](https://www.altlinux.org/Ports/loongarch64)
@@ -103,8 +111,11 @@ Known new-world (ports) distributions (alphabetical):
 * [Debian](https://wiki.debian.org/Ports/loong64)
 * [Fedora LoongArch Remix](https://github.com/fedora-remix-loongarch/releases-info)
 * [Gentoo](https://wiki.gentoo.org/wiki/Project:LoongArch)
+* [麒麟 (Kylin) V11](https://www.kylinos.cn/productPc/desktop/desktopMainV11/)
 * [Loong Arch Linux](https://github.com/loongarchlinux)
+* [Loongnix 25](https://www.loongnix.cn/zh/loongnix/)
 * [Slackware](https://github.com/shipujin/slackware-loongarch64)
+* [UOS V25](https://www.chinauos.com/resource/download-professional-V25)
 * [Yongbao](https://github.com/sunhaiyong1978/Yongbao)
 
 :::warning


### PR DESCRIPTION
Add specific version for old-world distros. 

Loongnix 26, UOS V25, and Kylin V11 are classified as new-world distributions. To reflect this better, specific versions are added for old-world ones in the documentation.

Meanwhile, on systems such as OpenCloudOS, users may encounter interpreter strings indicating `GNU/Linux 4.19.0` (e.g., `interpreter /lib64/ld-linux-loongarch-lp64d.so.1, for GNU/Linux 4.19.0`). A new entry is added for it to reflect that these binaries remain fundamentally new-world programs. The `4.19.0` version string appears because a special patch was applied to glibc in the build environment, which lowers the reported minimum kernel version for LoongArch.